### PR TITLE
VLI-721

### DIFF
--- a/versions/2.0/vipps-login-api.md
+++ b/versions/2.0/vipps-login-api.md
@@ -2,7 +2,7 @@
 
 API version: 2.0  
 
-Document version 3.0.0.
+Document version 4.0.0.
 
 See the
 [Vipps Login API](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md)

--- a/versions/2.0/vipps-login-migrate-api-1.0-to-2.0.md
+++ b/versions/2.0/vipps-login-migrate-api-1.0-to-2.0.md
@@ -20,7 +20,8 @@ Vipps Login will be the first service to integrate with this new endpoint.
 * Format of claim 'birthdate' is changed from **dd.mm.yyyy** to **yyyy-mm-dd**, to comply with the ISO 8601 format.
 * Claim address have been converted from a list of all address to an object of the default address. All other addresses are served under 'other_address' as a list. 
 This is done to comply with the OIDC-standard which expect address to be a json object.
-* User information is no longer served on the 'id_token'. Therefore, the 'id_token' will only contain user ids.
+* User information is no longer served on the 'id_token'. Therefore, the 'id_token' will only contain user ids. 
+This is done since the data in the id token should be used to lookup the authenticated user, while the userinfo endpoint should be used to fetch and store user information.   
 
 ## Convert to Vipps Login api version 2.0
 To control which response to serve we need the merchant to send inn scope 'api_version_2'.

--- a/versions/2.0/vipps-login-migrate-api-1.0-to-2.0.md
+++ b/versions/2.0/vipps-login-migrate-api-1.0-to-2.0.md
@@ -1,4 +1,4 @@
-# Vipps Login API
+# Vipps Login Api 2.0 migration
 
 Document version 1.0.0.
 
@@ -9,16 +9,18 @@ Reference:\
 ## Table of contents
 * [Overview](#overview)
 * [Convert to vipps login api version 2.0](#convert-to-vipps-login-api-version-20)
+* [Api changes](#api-changes)
 
-## Overview:
+## Overview
 To have a unified way of serving a merchant user information between our applications in Vipps we have implemented a new service handling this responsibility.
 Vipps Login will be the first service to integrate with this new endpoint.
-In vipps Login api version 2.0 we are changing format of scope 'nnin' to 'nin'.
-We have also have a major change to the response from the '/userinfo' endpoint.
-These are changes to the format of claim 'birthdate' from dd.mm.yyyy to yyyy-mm-dd to comply with the ISO 8601 format.
-To comply with the OIDC-standard and to highlight the address that the user has set as default in Vipps the claim 'address' have been converted from list of all addresses to only return the users default address,
-and the none default addresses are served under 'other_address'.
-We will also no longer serve user information in the 'id_token'.
+
+## Api changes
+* Scope 'nnin' is changed to 'nin'
+* Format of claim 'birthdate' is changed from **dd.mm.yyyy** to **yyyy-mm-dd**, to comply with the ISO 8601 format.
+* Claim address have been converted from a list of all address to an object of the default address. All other addresses are served under 'other_address' as a list. 
+This is done to comply with the OIDC-standard which expect address to be a json object.
+* User information is no longer served on the 'id_token'. Therefore, the 'id_token' will only contain user ids.
 
 ## Convert to Vipps Login api version 2.0
 To control which response to serve we need the merchant to send inn scope 'api_version_2'.
@@ -29,6 +31,5 @@ The other addresses, if any, of the user are now served under claim 'other_addre
 The format for claim 'birthdate' has been updated from dd.mm.yyyy to yyyy-mm-dd.
 See here for an example of the [userinfo response](https://vippsas.github.io/vipps-login-api/#/public/userinfo).
 If the integration to Vipps Login are using the 'id_token' for fetching user information, then this has to be converted to fetch these from the '/userinfo' endpoint.
-
 
 


### PR DESCRIPTION
Update migration guide to be more readable. Update document version to 4.0.0 for api v2, we should remove this document version since it have no use.