### PR TITLE
Polishing on case and titles. Removing some lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,15 @@ For information and to order the product go to:
 * [Vipps Login from phone number: How It Works](./vipps-login-from-phone-number-api-howitworks.md)
 * [Vipps Login + Vipps Recurring: How It Works](vipps-login-recurring-howitworks.md)
 
-## Getting started
+## Next steps
 
 See
 [Getting Started](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/vipps-getting-started)
 for information about API keys, product activation, how to make API calls, etc.
 
-## Developer guide
+Review the detailed documentation found here:
 
-* [API Quick Start](vipps-login-api-quick-start.md): Quick Start.
-* [API Guide](vipps-login-api.md): In-depth guide to the Login API.
+* [API quick start](vipps-login-api-quick-start.md): Quick start.
+* [API guide](vipps-login-api.md): In-depth guide to the Login API.
 * [API FAQ](vipps-login-api-faq.md): Questions and answers.
-* [API Reference](https://vippsas.github.io/vipps-developer-docs/api/login): Login API reference documentation.
-
+* [API reference](https://vippsas.github.io/vipps-developer-docs/api/login): Login API reference specifications.

--- a/vipps-login-api-checklist.md
+++ b/vipps-login-api-checklist.md
@@ -5,7 +5,7 @@ sidebar_position: 40
 ---
 END_METADATA -->
 
-# Vipps Login API Checklist
+# Checklist
 
 <!-- START_COMMENT -->
 
@@ -16,7 +16,7 @@ END_METADATA -->
 
 API version: 2.0.
 
-## Checklist
+## Checklist for full integration
 
 - [ ] Integration with the Vipps Login API is redirect based (i.e no embedded iframe)
 - [ ] Native app integrations use the [app-to-app flow](vipps-login-api.md#app-to-app-flow)

--- a/vipps-login-api-faq.md
+++ b/vipps-login-api-faq.md
@@ -6,7 +6,7 @@ pagination_next: null
 ---
 END_METADATA -->
 
-# Vipps Login API: Frequently Asked Questions
+# Frequently asked questions
 
 Here are the Login API FAQs.
 See the [Vipps Login API](vipps-login-api.md) for all the details.
@@ -88,7 +88,7 @@ First you activate Vipps Login:
 Then you can add the redirect URIs you need:
 ![Then you can add the redirect URIs you need](images/portal_direct_uris.jpeg)
 
-## What are the requirements for Redirect URIs?
+## What are the requirements for redirect URIs?
 
 We validate redirect URIs against a whitelist of pre-approved URIs. The URIs
 must be registered by the merchant on [portal.vipps.no](https://portal.vipps.no).
@@ -269,6 +269,7 @@ authentication/registration and thus login cannot be done in the user’s browse
 Vipps Login from phone number are reserved for such special cases.  If a merchant uses Vipps Login from phone number on webpages or in apps used by end-users (on their own device), access to the feature can be withdrawn.
 
 Vipps Login from phone number is a billed service. As such, we also need some details regarding invoicing:
+
  * Recipient name
  * Recipient email
  * Invoicing address
@@ -284,7 +285,7 @@ Send an email to [accessuserinfo@vipps.no](mailto:accessuserinfo@vipps.no) and s
 | Item                                                  | Description                                                                                                                                                                     | Example                                                                           | Comments                                                                                                                                  |
 |-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | Top text                                              | Specifies the purpose of collecting the consents                                                                                                                                | "Merchant AS would like to send you tailored offers in several digital channels." |                                                                                                                                           |
-| Subset of consents you would like to request.         | We offer a set of predefined consents. See [When using delegatedConsents, which consents does Vipps support?](#when-using-delegatedconsents-which-consents-does-vipps-support). | email, sms, digital, personal                                                     | If you want a consent type that we currently don't support, reach out to us at [accessuserinfo@vipps.no](mailto:accessuserinfo@vipps.no). |
+| Subset of consents you would like to request.         | We offer a set of predefined consents. See [When using delegatedConsents, which consents does Vipps support?](#when-using-delegatedconsents-which-consents-are-supported). | email, sms, digital, personal                                                     | If you want a consent type that we currently don't support, reach out to us at [accessuserinfo@vipps.no](mailto:accessuserinfo@vipps.no). |
 | Links to your membership terms and privacy statement. | We must review your terms to ensure that the flow is not intended to mislead or abuse end users.                                                                                | www.merchant.com/termsandconditions <br /> www.merchant.com/privacystatement      |                                                                                                                                           |
 | Recipient to sign DPA                                 | Vipps will function as a data processor and not have any ownership to the data involved. For more information, please visit merchant terms and conditions                       | recipient@merchant.com                                                            |                                                                                                                                           |
 

--- a/vipps-login-api-howitworks.md
+++ b/vipps-login-api-howitworks.md
@@ -5,7 +5,7 @@ sidebar_position: 13
 ---
 END_METADATA -->
 
-# Vipps Login in browser: How It Works
+# How it works in the browser
 
 <!-- START_COMMENT -->
 

--- a/vipps-login-from-phone-number-api-howitworks.md
+++ b/vipps-login-from-phone-number-api-howitworks.md
@@ -5,7 +5,7 @@ sidebar_position: 14
 ---
 END_METADATA -->
 
-# Vipps Login from phone number: How It Works
+# How it works from mobile
 
 <!-- START_COMMENT -->
 

--- a/vipps-login-recurring-howitworks.md
+++ b/vipps-login-recurring-howitworks.md
@@ -5,7 +5,7 @@ sidebar_position: 16
 ---
 END_METADATA -->
 
-# Vipps Login + Vipps Recurring: How It Works
+# How it works with Vipps Recurring
 
 <!-- START_COMMENT -->
 


### PR DESCRIPTION
I am making all the API document titles consistent and removing the api name in places, since it's redundant with the website title.