### PR TITLE
Revert "Update links to new userinfo page"

### DIFF
--- a/vipps-login-api.md
+++ b/vipps-login-api.md
@@ -1615,6 +1615,6 @@ For fetching userinfo the token received during the login flow must be used.
 
 [login-wellknown-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/login#tag/Vipps-Login-API/operation/wellKnown
 [login-discoveropenid-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/login#tag/Vipps-Login-API/operation/discoverOpenIDConfiguration
-[userinfo-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/userinfo#operation/getUserinfo
+[userinfo-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/login#tag/Userinfo-API/operation/userinfoAuthorizationCode
 [access-auth-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/login#tag/Vipps-Login-API/operation/oauthAuth
 [access-token-endpoint]: https://vippsas.github.io/vipps-developer-docs/api/login#tag/Vipps-Login-API/operation/oauth2Token


### PR DESCRIPTION
Reverts vippsas/vipps-login-api#193
Use the userinfo endpoint from the login swagger because it it actually different from the other one (ecom version)