### PR TITLE
Moved some details about activating Vipps Login to the portal page

### DIFF
--- a/api-guide/app-integration.md
+++ b/api-guide/app-integration.md
@@ -40,14 +40,16 @@ In either case it is important to avoid using static client secrets in the app f
 (For more information see <https://github.com/openid/AppAuth-Android#utilizing-client-secrets-dangerous> and <https://tools.ietf.org/html/rfc8252#section-8.5>).
 
 _Both_ URIs must be added in the [portal.vipps.no](https://portal.vipps.no/),
-you find more information on how to do this [here](https://vippsas.github.io/vipps-developer-docs/docs/APIs/login-api/vipps-login-api-faq.md#how-can-i-activate-and-set-up-vipps-login).
+you find more information on how to do this [Developer resources: Portal: How to setup login on your sales unit?](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/developer-resources/portal#how-to-setup-login-on-your-sales-unit).
 
 **Please note:** URIs specified on [portal.vipps.no](https://portal.vipps.no/)
 must be _exactly_ the same as used in the API calls. Be extra careful with
 trailing `/` and URL-encoded entities. If the URIs are not identical you will get
 this error:
 
->The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client
+```text
+The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client
+```
 
 The Vipps app will return some data with the return to the `app_callback_uri`.
 It contains two query parameters `state` and `resume_uri`.

--- a/vipps-login-api-faq.md
+++ b/vipps-login-api-faq.md
@@ -35,33 +35,9 @@ See:
 
 ## How can I activate and set up Vipps Login?
 
-On [portal.vipps.no](https://portal.vipps.no), in the same place as the
-`client_id` and `client_secret` described above, you can activate Vipps Login,
-and also add the redirect URIs needed for the service to work. This is the URL/URI of
-the page which the user is redirected to after finishing a login. See:
-[API endpoints](api-guide/integration.md#api-endpoints-required-from-the-merchant)
-as well as requirements for the URIs below.
+You can activate Vipps Login on the [portal.vipps.no](https://portal.vipps.no).
+See [Developer resources: Vipps portal: How to setup login on your sales unit](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/developer-resources/portal#how-to-setup-login-on-your-sales-unit).
 
-You will find the "Setup Vipps Login" option under the "Utvikler" menu,
-in the same place as you find your `client_id` and `client_secret`.
-Click "Setup login" for the sales unit you want to set up Vipps Login for.
-
-The "Setup login" button is on the right side of the sales unit overview:
-
-![You will find the Setup Vipps Login option in the same place as you find your `client_id` and `client_secret`](images/portal_setup_login.png)
-
-First you activate Vipps Login by clicking the "Activate Vipps Login" button:
-
-![First you activate Vipps Login](images/portal_setup.jpeg)
-
-Then you can add the redirect URIs you need:
-1. Enter the URI. It must be _exactly_ the same URI that you use when making
-   API requests. Remember if the actual URI specified with `redirect_uri`
-   has a trailing slash `/` or not.
-2. Click "Add URI" for the one or more URIs you are adding.
-3. Click "Save" to save all the URIs you have added.   
-
-![Then you can add the redirect URIs you need](images/portal_direct_uris.jpeg)
 
 ## What are the requirements for redirect URIs?
 
@@ -70,8 +46,8 @@ pre-approved URIs. The URIs must be registered by the merchant on
 [portal.vipps.no](https://portal.vipps.no)
 as described above.
 
-You can register as many URIs as you want to. You specify the URI that will be used with
-the query parameter `redirect_uri` on the initial request to the authentication
+You can register as many URIs as you want to. Specify the URI that will be used with
+the query parameter, `redirect_uri`, on the initial request to the `authentication`
 endpoint.
 
 **Please note:**

--- a/vipps-login-api-faq.md
+++ b/vipps-login-api-faq.md
@@ -108,7 +108,7 @@ This means that the `client_id` and `client_secret` used is not valid for Vipps 
 Please check:
 
 * Have you activated Vipps Login and set up a redirect URI? See:
-  [How can I activate and set up Vipps Login?](#how-can-i-activate-and-set-up-vipps-login)
+  [Developer resources: Portal: How to setup login on your sales unit?](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/developer-resources/portal#how-to-setup-login-on-your-sales-unit).
 * Have you double checked that the `redirect_uri` used in the API call is
   _exactly_ the same as the one specified on
   [portal.vipps.no](https://portal.vipps.no)?


### PR DESCRIPTION
I have moved some details about activating Vipps Login to the portal page, so this can link to that page now. This will show up here soon: https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/developer-resources/portal#how-to-setup-login-on-your-sales-unit